### PR TITLE
_android_utils.py: refactor documentation and fix start activity keyword

### DIFF
--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -27,7 +27,8 @@ class _AndroidUtilsKeywords(KeywordGroup):
     def set_network_connection_status(self, connectionStatus):
         """Sets the network connection status.\n
 
-        *Android only.* \n
+        *Android only.*
+
         Args:
          - connectionStatus: depending on what the network connection should be set to,
          choose one of the values below.
@@ -50,9 +51,10 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Retrieves the file at `path` and returns its content.\n
 
         *Android only.*
+
         Args:
          - _path_ - the path to the file on the device
-         - _decode_ - True/False decode the data (base64) before returning it (default=False)
+         - _decode_ - should be set to True/False to decode the data (base64) before returning it (default=False)
 
         Example:
         | ${file_content} | Pull File | /sdcard/downloads/file.extension |
@@ -67,6 +69,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Retrieves a folder at `path` and returns its zipped content.\n
 
         *Android only.*
+
         Args:
          - _path_ - the path to the folder on the device
          - _decode_ - True/False decode the data (base64) before returning it (default=False)
@@ -84,10 +87,11 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Puts the data in the file specified as `path`.\n
 
         *Android only.*
+    
         Args:
          - _path_ - the path on the device
          - _data_ - data to be written to the file
-         - _encode_ - True/False encode the data as base64 before writing it to the file (default=False)
+         - _encode_ - should be set to True/False to encode the data as base64 before writing it to the file (default=False)
         
         Example:
         | Push File | /sdcard/downloads/file.extension | ${data}
@@ -102,6 +106,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Deletes the file specified as `path`.\n
 
         *Android only.*
+
         Args:
          - _path_ - the path on the device
          - _timeout_ - delete command timeout
@@ -130,6 +135,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Waits for an activity: blocks until target activity presents or until the timeout is reached.\n
 
         *Android only.*
+
         Args:
          - _activity_ - target activity
          - _timeout_ - max wait time, in seconds
@@ -143,6 +149,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """ Installs the app via appium.\n
 
         *Android only.*
+    
         Args:
         - app_path - path to app
         - app_package - package of install app to verify
@@ -155,6 +162,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """ Sets the location.\n
 
         *Android only.*
+    
         Args:
         - _latitute_
         - _longitude_

--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -9,7 +9,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
     def open_notifications(self):
         """Opens and expands an Android device's notification drawer.
 
-        *ndroid only.*
+        *Android only.*
         """
         driver = self._current_application()
         driver.open_notifications()
@@ -25,9 +25,12 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return driver.network_connection
 
     def set_network_connection_status(self, connectionStatus):
-        """Sets the network connection Status.\n
+        """Sets the network connection status.\n
 
-        *Android only.*
+        *Android only.* \n
+        Args:
+         - connectionStatus: depending on what the network connection should be set to,
+         choose one of the values below.
 
         Possible values:
             | =Value= | =Alias=          | =Data= | =Wifi= | =Airplane Mode=  |
@@ -36,17 +39,23 @@ class _AndroidUtilsKeywords(KeywordGroup):
             |  2      | (Wifi only)      | 0      |   1    | 0                |
             |  4      | (Data only)      | 1      |   0    | 0                |
             |  6      | (All network on) | 1      |   1    | 0                |
+
+        Example:
+        | Set Network Connection Status | 1 |
         """
         driver = self._current_application()
         return driver.set_network_connection(int(connectionStatus))
 
     def pull_file(self, path, decode=False):
-        """Retrieves the file at `path` and return it's content.\n
+        """Retrieves the file at `path` and returns its content.\n
 
         *Android only.*
-
+        Args:
          - _path_ - the path to the file on the device
          - _decode_ - True/False decode the data (base64) before returning it (default=False)
+
+        Example:
+        | ${file_content} | Pull File | /sdcard/downloads/file.extension |
          """
         driver = self._current_application()
         theFile = driver.pull_file(path)
@@ -55,12 +64,15 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return str(theFile)
 
     def pull_folder(self, path, decode=False):
-        """Retrieves a folder at `path`. Returns the folder's contents zipped.\n
+        """Retrieves a folder at `path` and returns its zipped content.\n
 
         *Android only.*
-
+        Args:
          - _path_ - the path to the folder on the device
          - _decode_ - True/False decode the data (base64) before returning it (default=False)
+        
+        Example:
+        | ${folder_content} | Pull Folder | /sdcard/downloads/files |
         """
         driver = self._current_application()
         theFolder = driver.pull_folder(path)
@@ -72,10 +84,13 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """Puts the data in the file specified as `path`.\n
 
         *Android only.*
-
+        Args:
          - _path_ - the path on the device
          - _data_ - data to be written to the file
          - _encode_ - True/False encode the data as base64 before writing it to the file (default=False)
+        
+        Example:
+        | Push File | /sdcard/downloads/file.extension | ${data}
         """
         driver = self._current_application()
         data = to_bytes(data)
@@ -84,14 +99,16 @@ class _AndroidUtilsKeywords(KeywordGroup):
         driver.push_file(path, data)
 
     def delete_file(self, path, timeout=5000, include_stderr=True):
-        """Delete the file specified as `path`.\n
+        """Deletes the file specified as `path`.\n
 
         *Android only.*
-
+        Args:
          - _path_ - the path on the device
          - _timeout_ - delete command timeout
          - _includeStderr_ - whether exception will be thrown if the command's
                             return code is not zero
+        Example:
+        | Delete File | /sdcard/downloads/file.extension |
         """
         driver = self._current_application()
         driver.execute_script('mobile: shell', {
@@ -109,21 +126,22 @@ class _AndroidUtilsKeywords(KeywordGroup):
         driver = self._current_application()
         return driver.current_activity
 
+    # TODO: Check if deprecated!
     def start_activity(self, appPackage, appActivity, **opts):
         """Opens an arbitrary activity during a test. If the activity belongs to
         another application, that application is started and the activity is opened.\n
 
         *Android only.*
-
-        - _appPackage_ - The package containing the activity to start.
-        - _appActivity_ - The activity to start.
-        - _appWaitPackage_ - Begin automation after this package starts (optional).
-        - _appWaitActivity_ - Begin automation after this activity starts (optional).
-        - _intentAction_ - Intent to start (opt_ional).
-        - _intentCategory_ - Intent category to start (optional).
-        - _intentFlags_ - Flags to send to the intent (optional).
-        - _optionalIntentArguments_ - Optional arguments to the intent (optional).
-        - _dontStopAppOnReset_ - Should the app be stopped on reset (optional)?
+        Args:
+        - _appPackage_ - the package containing the activity to start.
+        - _appActivity_ - the activity to start.
+        - _appWaitPackage_ - begin automation after this package starts (optional).
+        - _appWaitActivity_ - begin automation after this activity starts (optional).
+        - _intentAction_ - intent to start (optional).
+        - _intentCategory_ - intent category to start (optional).
+        - _intentFlags_ - flags to send to the intent (optional).
+        - _optionalIntentArguments_ - optional arguments to the intent (optional).
+        - _dontStopAppOnReset_ - should the app be stopped on reset (optional)?
 
         """
 
@@ -140,7 +158,6 @@ class _AndroidUtilsKeywords(KeywordGroup):
             'optional_intent_arguments': 'optionalIntentArguments',
             'dont_stop_app_on_reset': 'dontStopAppOnReset'
         }
-
         data = {}
 
         for key, value in arguments.items():
@@ -151,10 +168,10 @@ class _AndroidUtilsKeywords(KeywordGroup):
         driver.start_activity(app_package=appPackage, app_activity=appActivity, **data)
 
     def wait_activity(self, activity, timeout, interval=1):
-        """Wait for an activity: block until target activity presents or time out.\n
+        """Waits for an activity: blocks until target activity presents or until the timeout is reached.\n
 
         *Android only.*
-
+        Args:
          - _activity_ - target activity
          - _timeout_ - max wait time, in seconds
          - _interval_ - sleep interval between retries, in seconds
@@ -164,10 +181,10 @@ class _AndroidUtilsKeywords(KeywordGroup):
             raise TimeoutException(msg="Activity %s never presented, current activity: %s" % (activity, self.get_activity()))
 
     def install_app(self, app_path, app_package):
-        """ Install App via Appium\n
+        """ Installs the app via appium.\n
 
         *Android only.*
-
+        Args:
         - app_path - path to app
         - app_package - package of install app to verify
         """
@@ -176,10 +193,10 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return driver.is_app_installed(app_package)
 
     def set_location(self, latitude, longitude, altitude=10):
-        """ Set location\n
+        """ Sets the location.\n
 
         *Android only.*
-
+        Args:
         - _latitute_
         - _longitude_
         - _altitude_ = 10 [optional]

--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -126,47 +126,6 @@ class _AndroidUtilsKeywords(KeywordGroup):
         driver = self._current_application()
         return driver.current_activity
 
-    # TODO: Check if deprecated!
-    def start_activity(self, appPackage, appActivity, **opts):
-        """Opens an arbitrary activity during a test. If the activity belongs to
-        another application, that application is started and the activity is opened.\n
-
-        *Android only.*
-        Args:
-        - _appPackage_ - the package containing the activity to start.
-        - _appActivity_ - the activity to start.
-        - _appWaitPackage_ - begin automation after this package starts (optional).
-        - _appWaitActivity_ - begin automation after this activity starts (optional).
-        - _intentAction_ - intent to start (optional).
-        - _intentCategory_ - intent category to start (optional).
-        - _intentFlags_ - flags to send to the intent (optional).
-        - _optionalIntentArguments_ - optional arguments to the intent (optional).
-        - _dontStopAppOnReset_ - should the app be stopped on reset (optional)?
-
-        """
-
-
-        # Almost the same code as in appium's start activity,
-        # just to keep the same keyword names as in open application
-
-        arguments = {
-            'app_wait_package': 'appWaitPackage',
-            'app_wait_activity': 'appWaitActivity',
-            'intent_action': 'intentAction',
-            'intent_category': 'intentCategory',
-            'intent_flags': 'intentFlags',
-            'optional_intent_arguments': 'optionalIntentArguments',
-            'dont_stop_app_on_reset': 'dontStopAppOnReset'
-        }
-        data = {}
-
-        for key, value in arguments.items():
-            if value in opts:
-                data[key] = opts[value]
-
-        driver = self._current_application()
-        driver.start_activity(app_package=appPackage, app_activity=appActivity, **data)
-
     def wait_activity(self, activity, timeout, interval=1):
         """Waits for an activity: blocks until target activity presents or until the timeout is reached.\n
 

--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -94,7 +94,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
          - ``encode`` - should be set to True/False to encode the data as base64 before writing it to the file (default=False)
         
         Example:
-        | Push File | /sdcard/downloads/file.extension | ${data}
+        | Push File | /sdcard/downloads/file.extension | ${data} |
         """
         driver = self._current_application()
         data = to_bytes(data)

--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -30,7 +30,7 @@ class _AndroidUtilsKeywords(KeywordGroup):
         *Android only.*
 
         Args:
-         - connectionStatus: depending on what the network connection should be set to,
+         - ``connectionStatus``: depending on what the network connection should be set to,
          choose one of the values below.
 
         Possible values:
@@ -48,13 +48,13 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return driver.set_network_connection(int(connectionStatus))
 
     def pull_file(self, path, decode=False):
-        """Retrieves the file at `path` and returns its content.\n
+        """Retrieves the file at ``path`` and returns its content.\n
 
         *Android only.*
 
         Args:
-         - _path_ - the path to the file on the device
-         - _decode_ - should be set to True/False to decode the data (base64) before returning it (default=False)
+         - ``path`` - the path to the file on the device
+         - ``decode`` - should be set to True/False to decode the data (base64) before returning it (default=False)
 
         Example:
         | ${file_content} | Pull File | /sdcard/downloads/file.extension |
@@ -66,13 +66,13 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return str(theFile)
 
     def pull_folder(self, path, decode=False):
-        """Retrieves a folder at `path` and returns its zipped content.\n
+        """Retrieves a folder at ``path`` and returns its zipped content.\n
 
         *Android only.*
 
         Args:
-         - _path_ - the path to the folder on the device
-         - _decode_ - True/False decode the data (base64) before returning it (default=False)
+         - ``path`` - the path to the folder on the device
+         - ``decode`` - True/False decode the data (base64) before returning it (default=False)
         
         Example:
         | ${folder_content} | Pull Folder | /sdcard/downloads/files |
@@ -84,14 +84,14 @@ class _AndroidUtilsKeywords(KeywordGroup):
         return theFolder
 
     def push_file(self, path, data, encode=False):
-        """Puts the data in the file specified as `path`.\n
+        """Puts the data in the file specified as ``path``.\n
 
         *Android only.*
     
         Args:
-         - _path_ - the path on the device
-         - _data_ - data to be written to the file
-         - _encode_ - should be set to True/False to encode the data as base64 before writing it to the file (default=False)
+         - ``path`` - the path on the device
+         - ``data`` - data to be written to the file
+         - ``encode`` - should be set to True/False to encode the data as base64 before writing it to the file (default=False)
         
         Example:
         | Push File | /sdcard/downloads/file.extension | ${data}
@@ -103,14 +103,14 @@ class _AndroidUtilsKeywords(KeywordGroup):
         driver.push_file(path, data)
 
     def delete_file(self, path, timeout=5000, include_stderr=True):
-        """Deletes the file specified as `path`.\n
+        """Deletes the file specified as ``path``.\n
 
         *Android only.*
 
         Args:
-         - _path_ - the path on the device
-         - _timeout_ - delete command timeout
-         - _includeStderr_ - whether exception will be thrown if the command's
+         - ``path`` - the path on the device
+         - ``timeout`` - delete command timeout
+         - ``includeStderr`` - whether exception will be thrown if the command's
                             return code is not zero
         Example:
         | Delete File | /sdcard/downloads/file.extension |
@@ -137,9 +137,9 @@ class _AndroidUtilsKeywords(KeywordGroup):
         *Android only.*
 
         Args:
-         - _activity_ - target activity
-         - _timeout_ - max wait time, in seconds
-         - _interval_ - sleep interval between retries, in seconds
+         - ``activity`` - target activity
+         - ``timeout`` - max wait time, in seconds
+         - ``interval`` - sleep interval between retries, in seconds
         """
         driver = self._current_application()
         if not driver.wait_activity(activity=activity, timeout=float(timeout), interval=float(interval)):
@@ -151,8 +151,8 @@ class _AndroidUtilsKeywords(KeywordGroup):
         *Android only.*
     
         Args:
-        - app_path - path to app
-        - app_package - package of install app to verify
+        - ``app_path`` - path to app
+        - ``app_package`` - package of install app to verify
         """
         driver = self._current_application()
         driver.install_app(app_path)
@@ -164,9 +164,9 @@ class _AndroidUtilsKeywords(KeywordGroup):
         *Android only.*
     
         Args:
-        - _latitute_
-        - _longitude_
-        - _altitude_ = 10 [optional]
+        - ``latitute``
+        - ``longitude``
+        - ``altitude`` = 10 [optional]
         """
         driver = self._current_application()
         driver.set_location(latitude,longitude,altitude)

--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -4,6 +4,8 @@ import base64
 from .keywordgroup import KeywordGroup
 from selenium.common.exceptions import TimeoutException
 from kitchen.text.converters import to_bytes
+from robot.api import logger
+
 
 class _AndroidUtilsKeywords(KeywordGroup):
     def open_notifications(self):
@@ -170,3 +172,66 @@ class _AndroidUtilsKeywords(KeywordGroup):
         """
         driver = self._current_application()
         driver.set_location(latitude,longitude,altitude)
+
+    def start_activity(self, appPackage, appActivity, **opts):
+        """ Starts the given activity intent. It invokes the `am start/ am start-activity` command under the hood.
+        This keyword extends the functionality of the Start Activity app management API.
+        The intent is built with the ``appPackage`` and ``appActivity``.
+
+        *Android only.*
+
+        Args:
+         - ``appPackage`` - package of install app to verify
+         - ``appActivity`` - activity that should be launched
+         - ``user`` - the user ID for which the service is started (the current user is used by default)
+         - ``wait`` - set to true if you want to block the method call until the Activity Manager's process returns the control to the system
+         - ``stop`` - set to true to force stop the target app before starting the activity
+         - ``windowingMode`` - the windowing mode to launch the activity into
+         - ``activityType`` - the activity type to launch the activity as
+         - ``action`` - action name (actual value for the Activity Manager's `-a` argument)
+         - ``uri`` - unified resource identifier (actual value for the Activity Manager's `-d` argument)
+         - ``mimeType`` - the actual value for the Activity Manager's `-t` argument
+         - ``identifier`` - optional identifier (actual value for the Activity Manager's `-i` argument)
+         - ``categories`` - one or more category names (actual value for the Activity Manager's `-c` argument)
+         - ``component`` - component name (actual value for the Activity Manager's `-n` argument)
+         - ``package`` - package name (actual value for the Activity Manager's `-p` argument)
+         - ``extras`` - optional intent arguments, must be represented as an array of arrays, where each subarray item contains two or three string items: value type, key and the value itself
+         - ``flags`` - intent startup-specific flags as a hexadecimal string
+
+        For more information please refer to https://github.com/appium/appium-uiautomator2-driver/blob/master/README.md#mobile-startactivity.
+
+        Example:
+        | Start Activity | com.google.android.deskclock | com.android.deskclock.DeskClock |
+        """
+        
+        arguments = {
+            'user':'user',
+            'wait': 'wait',
+            'stop' : 'stop',
+            'windowingMode': 'windowingMode',
+            'activityType': 'activityType',
+            'action': 'action',
+            'uri': 'uri',
+            'mimeType': 'mimeType',
+            'identifier': 'identifier',
+            'categories': 'categories',
+            'component' : 'component',
+            'package': 'package',
+            'extras': 'extras',
+            'flags':'flags'
+        }
+
+        data = {}
+
+        data['intent'] = f"{appPackage}/{appActivity}"
+
+        invalid_args = [key for key in opts.keys() if key not in arguments]
+        if invalid_args:
+            logger.warn(f"Invalid optional arguments passed: {', '.join(invalid_args)}. These will be ignored. ")
+
+        for key, value in arguments.items():
+            if value in opts:
+                data[key] = opts[value]
+    
+        driver = self._current_application()
+        driver.execute_script('mobile: startActivity', data)


### PR DESCRIPTION
This contains a refactored documentation for _android_utils.py and the fix of start_activity (using mobile: startActivity), as this is not available in https://github.com/appium/python-client/blob/fa7ba6ee5ee91c914f69e34547993af62995462f/appium/webdriver/extensions/android/activities.py anymore.
See related issue: https://github.com/serhatbolsu/robotframework-appiumlibrary/issues/409 